### PR TITLE
Forward compatibility port for new scipy.

### DIFF
--- a/pycorrfit/trace.py
+++ b/pycorrfit/trace.py
@@ -4,6 +4,10 @@ import hashlib
 import numpy as np
 import scipy.integrate as spintg
 
+# forward compatibility patch for scipy >= 1.10
+# aliasing simpson as simps
+if not hasattr(spintg, "simps"):
+        spintg.simps = spintg.simpson
 
 class Trace(object):
     """ unifies trace handling


### PR DESCRIPTION
This patch fixes incompatibility issue, without affecting users with old versions of `scipy`

Modern scipy does not support `simps` as function name, it is now called `simpson`.
Implementation is the same, it's only a name change.