### PR TITLE
calculate failure rate using total number of test cases

### DIFF
--- a/tests/test_fit_models.py
+++ b/tests/test_fit_models.py
@@ -113,7 +113,7 @@ def test_fit_single_parameter_with_noise_one_permille():
 @pytest.mark.filterwarnings('ignore::pycorrfit.fit.StuckParameterWarning')
 def test_fit_single_parameter_with_noise_two_percent():
     succlist, faillist = fit_single_parameter_with_noise(noise=0.02)
-    if len(faillist)/len(succlist) > .05:
+    if len(faillist) / (len(succlist) + len(faillist)) > 0.05:
         raise ValueError("Model tests failed for:\n", faillist)
 
 


### PR DESCRIPTION
The test `test_fit_single_parameter_with_noise_two_percent()` is intended to verify that no more than 5% of model fits fail when 2% random noise is added to the synthetic data.

The previous implementation calculated the failure rate as:

```
len(faillist) / len(succlist)
```

This uses only the number of successful fits as the denominator, which makes the threshold slightly stricter than intended. For example, 5 failures and 95 successes result in a value of 5/95 = 5.26%, even though the actual failure rate is exactly 5% (5 out of 100 total runs).

This patch changes the calculation to:

```
len(faillist) / (len(succlist) + len(faillist))
```

Using the total number of test cases as the denominator correctly reflects the proportion of failed fits and matches the stated 5% acceptance criterion.

This also makes the test less sensitive to small architecture-dependent numerical differences in the fitting routines, which can otherwise lead to spurious failures on platforms such as ppc64el.
